### PR TITLE
[patch] URL-encode bookmarks tag parameter

### DIFF
--- a/internal/client/artwork_bookmarks.go
+++ b/internal/client/artwork_bookmarks.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/fekoneko/piximan/internal/client/dto"
@@ -13,10 +14,11 @@ import (
 func (c *Client) ArtworkBookmarksAuthorized(
 	userId uint64, tag *string, offset uint64, limit uint64, private bool,
 ) (results []BookmarkResult, total uint64, err error) {
+	escapedTag := utils.FromPtrTransform(tag, url.QueryEscape, "")
 	visivility := utils.If(private, "hide", "show")
 	url := fmt.Sprintf(
 		"https://www.pixiv.net/ajax/user/%v/illusts/bookmarks?tag=%v&offset=%v&limit=%v&rest=%v",
-		userId, utils.FromPtr(tag, ""), offset, limit, visivility,
+		userId, escapedTag, offset, limit, visivility,
 	)
 	body, _, err := c.DoAuthorized(url, nil)
 	if err != nil {

--- a/internal/client/novel_bookmarks.go
+++ b/internal/client/novel_bookmarks.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/fekoneko/piximan/internal/client/dto"
@@ -13,10 +14,11 @@ import (
 func (c *Client) NovelBookmarksAuthorized(
 	userId uint64, tag *string, offset uint64, limit uint64, private bool,
 ) (results []BookmarkResult, total uint64, err error) {
+	escapedTag := utils.FromPtrTransform(tag, url.QueryEscape, "")
 	visivility := utils.If(private, "hide", "show")
 	url := fmt.Sprintf(
 		"https://www.pixiv.net/ajax/user/%v/novels/bookmarks?tag=%v&offset=%v&limit=%v&rest=%v",
-		userId, utils.FromPtr(tag, ""), offset, limit, visivility,
+		userId, escapedTag, offset, limit, visivility,
 	)
 	body, _, err := c.DoAuthorized(url, nil)
 	if err != nil {

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -22,7 +22,7 @@ var configPath = filepath.Join(homePath, ".piximan", "config.yaml")
 
 // Stores and reads configuration. You can directly access and modify public fields and then
 // call Write() to save the changes on the disk.
-// SessionId() is decrypted lazily and cached in the Storage. WriteSessionId() writes the
+// SessionId() is decrypted lazily and cached in the Storage.WriteSessionId() writes the
 // encrypted session id to the disk separately from other fields.
 type Storage struct {
 	cipher            cipher.Block

--- a/internal/logger/output.go
+++ b/internal/logger/output.go
@@ -20,7 +20,7 @@ func (l *Logger) log(message string, args ...any) {
 type RemoveBarFunc func()
 type UpdateBarFunc func(int, int)
 
-// track request internally and return handlers to update its state
+// Track request internally and return handlers to update its state.
 func (l *Logger) registerRequest(url string, authorized bool) (RemoveBarFunc, UpdateBarFunc) {
 	l.mutex.Lock()
 	l.numRequests++

--- a/internal/logger/public.go
+++ b/internal/logger/public.go
@@ -78,13 +78,13 @@ func (l *Logger) MaybeErrors(errs []error, prefix string, args ...any) {
 
 func (l *Logger) Request(url string) (RemoveBarFunc, UpdateBarFunc) {
 	removeBar, updateBar := l.registerRequest(url, false)
-	l.log(requestPrefix + url)
+	l.log("%v%v", requestPrefix, url)
 	return removeBar, updateBar
 }
 
 func (l *Logger) AuthorizedRequest(url string) (RemoveBarFunc, UpdateBarFunc) {
 	removeBar, updateBar := l.registerRequest(url, true)
-	l.log(authRequestPrefix + url)
+	l.log("%v%v", authRequestPrefix, url)
 	return removeBar, updateBar
 }
 


### PR DESCRIPTION
Providing non-ascii characters for `--tag` argument broke in all versions. Probably was caused by some changes on Pixiv end. Anyways, now you can also safely use any characters in the tag name!